### PR TITLE
gardener: disable 1.31 test

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -181,7 +181,6 @@
       jobs:
         - e2e-tests-gardener-1.29-quick
         - e2e-tests-gardener-1.30-quick
-        - e2e-tests-gardener-1.31-quick
         - e2e-tests-openstack
     periodic-hourly:
       jobs:


### PR DESCRIPTION
Flow "Shoot cluster reconciliation" encountered task errors: [task "Initializing connection to Shoot" failed: retry failed with context deadline exceeded, last error: error creating new ClientSet for key "garden-cruv4yqhsc/e7c57997": error discovering kubernetes version: unsupported kubernetes version "v1.31.2"] Operation will be retried.